### PR TITLE
feat: customizable sidebar panes

### DIFF
--- a/Noted.xcodeproj/project.pbxproj
+++ b/Noted.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		176429857B534B116295B882 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA991681C049F5B9232E8AD /* Theme.swift */; };
 		2EA295E826A97E3D7842F31B /* AppStateRefreshFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BD246CBBCDF6CFF2436ECD /* AppStateRefreshFilesTests.swift */; };
 		3F80F8E1B9FC707EA01334FA /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E43EF1E8A2E10F1E9B970C /* EditorView.swift */; };
+		41730ECBD4020B9F1743468A /* FileTreeHiddenItemsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67C09A17B5F6D7F9D5FF0C2 /* FileTreeHiddenItemsTests.swift */; };
 		4343A4190A6FA3B0BB2F33F7 /* SettingsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A39596E7D194F46FDA0E89C /* SettingsManagerTests.swift */; };
 		49B951A7B560E5F2ACA2D1B7 /* AppStateSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC1CC9828325A2D58F447A2 /* AppStateSearchTests.swift */; };
 		4DED39B222B1B21E06683122 /* AppStateFileOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC3AEA452E7B5640E74BBE7 /* AppStateFileOperationsTests.swift */; };
@@ -31,6 +32,7 @@
 		C22507A911877F763C77ED86 /* AppStateCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BED738E87303BE22FE80D3C /* AppStateCoreTests.swift */; };
 		C4780A4386EE882320F1487C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 21BECAB9CC4CDFD05C5164B5 /* Assets.xcassets */; };
 		C47B40FD4775977503E93CB8 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA6E810541C500FD0E733DE /* AppState.swift */; };
+		CC26BB705C75D5B6AF7AF32D /* AppStateTagTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05487CCCEDE6E807426972BD /* AppStateTagTabsTests.swift */; };
 		CEDDD9E80508946613FA8BA1 /* AppStateRelativePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0392F77B111B0D8E9ED0AE0B /* AppStateRelativePathTests.swift */; };
 		D2BEBDFC72C9D8D865FC5981 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF46412D5210FC81403BA6DD /* SettingsView.swift */; };
 		D6D1324905B4911E14794C63 /* GitErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9118A97F8E84287AB07F8F /* GitErrorTests.swift */; };
@@ -55,6 +57,7 @@
 
 /* Begin PBXFileReference section */
 		0392F77B111B0D8E9ED0AE0B /* AppStateRelativePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRelativePathTests.swift; sourceTree = "<group>"; };
+		05487CCCEDE6E807426972BD /* AppStateTagTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTagTabsTests.swift; sourceTree = "<group>"; };
 		152582446E9AC0B1343551D2 /* NotedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotedApp.swift; sourceTree = "<group>"; };
 		1736A971B7173F018108BF51 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		1A9118A97F8E84287AB07F8F /* GitErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitErrorTests.swift; sourceTree = "<group>"; };
@@ -88,6 +91,7 @@
 		C64E820AF16E4DCABB5A5F7E /* AppStateTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTagsTests.swift; sourceTree = "<group>"; };
 		C6E776DDA97E544C924703CD /* TerminalPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneView.swift; sourceTree = "<group>"; };
 		D03209C4FF3A5BE985FE616F /* FolderPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderPickerView.swift; sourceTree = "<group>"; };
+		D67C09A17B5F6D7F9D5FF0C2 /* FileTreeHiddenItemsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeHiddenItemsTests.swift; sourceTree = "<group>"; };
 		D8E43EF1E8A2E10F1E9B970C /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		DC747A709A4B2CDA0979E7F8 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		EF46412D5210FC81403BA6DD /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -162,8 +166,10 @@
 				9AC1CC9828325A2D58F447A2 /* AppStateSearchTests.swift */,
 				5473BF2F01D6878F693C75B8 /* AppStateTabsTests.swift */,
 				C64E820AF16E4DCABB5A5F7E /* AppStateTagsTests.swift */,
+				05487CCCEDE6E807426972BD /* AppStateTagTabsTests.swift */,
 				2D56A9DD722BD1AD0B8363E6 /* AppStateTemplatesTests.swift */,
 				C43352A91B43578BBD8CCD30 /* AppStateWikiLinkTests.swift */,
+				D67C09A17B5F6D7F9D5FF0C2 /* FileTreeHiddenItemsTests.swift */,
 				437D3F990E7EFE2A8E221A73 /* GitAutoSaveTests.swift */,
 				1A9118A97F8E84287AB07F8F /* GitErrorTests.swift */,
 				727FA8227BA84DB28E7502EE /* GitServiceTests.swift */,
@@ -272,9 +278,11 @@
 				A9706FF815267B9D66AE5C75 /* AppStateSaveTests.swift in Sources */,
 				49B951A7B560E5F2ACA2D1B7 /* AppStateSearchTests.swift in Sources */,
 				7284EDEC4858322D1FD71AE0 /* AppStateTabsTests.swift in Sources */,
+				CC26BB705C75D5B6AF7AF32D /* AppStateTagTabsTests.swift in Sources */,
 				D94A9369C2EEF300633DF537 /* AppStateTagsTests.swift in Sources */,
 				86B64C8EF7AD9989C55DD568 /* AppStateTemplatesTests.swift in Sources */,
 				DB2306C131D91D6B9DF0ABD9 /* AppStateWikiLinkTests.swift in Sources */,
+				41730ECBD4020B9F1743468A /* FileTreeHiddenItemsTests.swift in Sources */,
 				8186813525CDD3D791D83D77 /* GitAutoSaveTests.swift in Sources */,
 				D6D1324905B4911E14794C63 /* GitErrorTests.swift in Sources */,
 				84D7158052556F10DD6101E6 /* GitServiceTests.swift in Sources */,

--- a/Noted/ContentView.swift
+++ b/Noted/ContentView.swift
@@ -39,7 +39,7 @@ struct ContentView: View {
                     }
 
                     if isRightSidebarVisible {
-                        SidebarContainerView(isLeft: false)
+                        SidebarContainerView(settings: appState.settings, isLeft: false)
                             .frame(minWidth: 280, idealWidth: 340, maxWidth: 620)
                             .background(NotedTheme.panel)
                     }
@@ -173,7 +173,7 @@ struct ContentView: View {
 
     @ViewBuilder
     private var leftSidebar: some View {
-        SidebarContainerView(isLeft: true)
+        SidebarContainerView(settings: appState.settings, isLeft: true)
     }
 
     private var headerBar: some View {
@@ -603,60 +603,151 @@ private struct RootNoteSheet: View {
 
 struct SidebarContainerView: View {
     @EnvironmentObject var appState: AppState
+    @ObservedObject private var settings: SettingsManager
     let isLeft: Bool
-    
+
+    init(settings: SettingsManager, isLeft: Bool) {
+        self.settings = settings
+        self.isLeft = isLeft
+    }
+
     var panes: [SidebarPane] {
-        let allPanes = isLeft ? appState.settings.leftSidebarPanes : appState.settings.rightSidebarPanes
-        return allPanes.filter { pane in
-            if pane == .links {
-                return true // Always show, we'll remove the toggle
-            }
-            return true
+        isLeft ? settings.leftSidebarPanes : settings.rightSidebarPanes
+    }
+
+    private var heights: [String: CGFloat] {
+        get { isLeft ? settings.leftPaneHeights : settings.rightPaneHeights }
+        nonmutating set {
+            if isLeft { settings.leftPaneHeights = newValue }
+            else { settings.rightPaneHeights = newValue }
         }
     }
-    
+
     var body: some View {
-        if panes.isEmpty {
-            VStack {
-                Spacer()
-                Text("Drag panels here")
-                    .font(.system(size: 12, weight: .medium, design: .rounded))
-                    .foregroundStyle(NotedTheme.textMuted)
-                Spacer()
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(NotedTheme.panel)
-            .onDrop(of: [.plainText], isTargeted: nil) { providers in
-                handleDrop(providers: providers, at: 0)
-            }
-        } else {
-            VSplitView {
-                ForEach(panes) { pane in
-                    SidebarPaneWrapper(pane: pane, isLeft: isLeft)
+        GeometryReader { geo in
+            if panes.isEmpty {
+                EmptyDropZone(settings: settings, isLeft: isLeft)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(Array(panes.enumerated()), id: \.element.id) { index, pane in
+                        let h = heights[pane.rawValue] ?? defaultHeight(for: pane, total: geo.size.height)
+
+                        SidebarPaneWrapper(pane: pane, settings: settings, isLeft: isLeft)
+                            .frame(height: h)
+
+                        if index < panes.count - 1 {
+                            ResizeDivider { delta in
+                                let nextPane = panes[index + 1]
+                                let currentH = heights[pane.rawValue] ?? defaultHeight(for: pane, total: geo.size.height)
+                                let nextH = heights[nextPane.rawValue] ?? defaultHeight(for: nextPane, total: geo.size.height)
+                                let minH: CGFloat = 80
+                                let newCurrent = currentH + delta
+                                let newNext = nextH - delta
+                                guard newCurrent >= minH && newNext >= minH else { return }
+                                heights[pane.rawValue] = newCurrent
+                                heights[nextPane.rawValue] = newNext
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .onChange(of: panes) { _ in
+                    // Clear stored heights when layout changes so panes get a fresh equal split
+                    if isLeft { settings.leftPaneHeights = [:] }
+                    else { settings.rightPaneHeights = [:] }
                 }
             }
         }
+        .background(NotedTheme.panel)
     }
-    
-    private func handleDrop(providers: [NSItemProvider], at index: Int) -> Bool {
-        guard let provider = providers.first else { return false }
-        
-        provider.loadObject(ofClass: NSString.self) { string, _ in
-            guard let id = string as? String, let draggedPane = SidebarPane(rawValue: id) else { return }
-            
-            DispatchQueue.main.async {
-                appState.settings.leftSidebarPanes.removeAll { $0 == draggedPane }
-                appState.settings.rightSidebarPanes.removeAll { $0 == draggedPane }
-                
-                var targetArray = isLeft ? appState.settings.leftSidebarPanes : appState.settings.rightSidebarPanes
-                let safeIndex = min(max(0, index), targetArray.count)
-                targetArray.insert(draggedPane, at: safeIndex)
-                
-                if isLeft {
-                    appState.settings.leftSidebarPanes = targetArray
-                } else {
-                    appState.settings.rightSidebarPanes = targetArray
+
+    private func defaultHeight(for pane: SidebarPane, total: CGFloat) -> CGFloat {
+        let dividerSpace = CGFloat(max(0, panes.count - 1)) * 6
+        return max(80, (total - dividerSpace) / CGFloat(panes.count))
+    }
+}
+
+struct ResizeDivider: View {
+    let onDrag: (CGFloat) -> Void
+
+    @State private var isDragging = false
+    @State private var lastY: CGFloat = 0
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(isDragging ? NotedTheme.accent.opacity(0.6) : NotedTheme.border)
+                .frame(height: isDragging ? 3 : 1)
+
+            // Wider invisible hit area
+            Color.clear
+                .frame(height: 6)
+                .contentShape(Rectangle())
+        }
+        .frame(height: 6)
+        .onHover { inside in
+            if inside { NSCursor.resizeUpDown.push() }
+            else { NSCursor.pop() }
+        }
+        .gesture(
+            DragGesture(minimumDistance: 1)
+                .onChanged { value in
+                    if !isDragging {
+                        isDragging = true
+                        lastY = 0
+                    }
+                    let delta = value.translation.height - lastY
+                    lastY = value.translation.height
+                    onDrag(delta)
                 }
+                .onEnded { _ in
+                    isDragging = false
+                    lastY = 0
+                    NSCursor.pop()
+                }
+        )
+    }
+}
+
+// Empty sidebar drop target
+struct EmptyDropZone: View {
+    @ObservedObject var settings: SettingsManager
+    let isLeft: Bool
+    @State private var isTargeted = false
+
+    var body: some View {
+        VStack {
+            Spacer()
+            Text("Drop panels here")
+                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .foregroundStyle(isTargeted ? NotedTheme.accent : NotedTheme.textMuted)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, minHeight: 200)
+        .background(isTargeted ? NotedTheme.accent.opacity(0.08) : Color.clear)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(isTargeted ? NotedTheme.accent.opacity(0.5) : Color.clear, lineWidth: 1)
+                .padding(4)
+        )
+        .onDrop(of: [.utf8PlainText], isTargeted: $isTargeted) { providers in
+            loadAndMove(providers: providers, insertIndex: 0)
+        }
+    }
+
+    private func loadAndMove(providers: [NSItemProvider], insertIndex: Int) -> Bool {
+        guard let provider = providers.first else { return false }
+        provider.loadItem(forTypeIdentifier: "public.utf8-plain-text", options: nil) { item, _ in
+            guard let data = item as? Data,
+                  let id = String(data: data, encoding: .utf8),
+                  let draggedPane = SidebarPane(rawValue: id) else { return }
+            DispatchQueue.main.async {
+                settings.leftSidebarPanes.removeAll { $0 == draggedPane }
+                settings.rightSidebarPanes.removeAll { $0 == draggedPane }
+                var target = isLeft ? settings.leftSidebarPanes : settings.rightSidebarPanes
+                target.insert(draggedPane, at: min(insertIndex, target.count))
+                if isLeft { settings.leftSidebarPanes = target }
+                else { settings.rightSidebarPanes = target }
             }
         }
         return true
@@ -664,37 +755,70 @@ struct SidebarContainerView: View {
 }
 
 struct SidebarPaneWrapper: View {
-    @EnvironmentObject var appState: AppState
+    @ObservedObject var settings: SettingsManager
     let pane: SidebarPane
     let isLeft: Bool
-    
+
+    @State private var headerTargeted = false
+    @State private var contentTargeted = false
+    @State private var headerHovered = false
+    @State private var isDraggingHeader = false
+
     var body: some View {
         VStack(spacing: 0) {
-            // Header with drag handle
+            // Drop indicator above — visible while hovering over header
+            Rectangle()
+                .fill(NotedTheme.accent)
+                .frame(height: 2)
+                .opacity(headerTargeted ? 1 : 0)
+
+            // Header — this is the drag handle
             HStack(spacing: 6) {
                 Image(systemName: "line.3.horizontal")
                     .font(.system(size: 10, weight: .bold))
                     .foregroundColor(NotedTheme.textMuted)
                     .frame(width: 14)
-                
+
                 Text(pane.title)
                     .font(.system(size: 11, weight: .bold, design: .rounded))
                     .tracking(1.8)
                     .foregroundStyle(NotedTheme.textMuted)
                     .textCase(.uppercase)
-                
+
                 Spacer()
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .background(NotedTheme.panelElevated)
+            .onHover { hovering in
+                headerHovered = hovering
+                if hovering {
+                    NSCursor.openHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
             .onDrag {
-                NSItemProvider(object: pane.rawValue as NSString)
+                NSCursor.closedHand.push()
+                return NSItemProvider(object: pane.rawValue as NSString)
+            } preview: {
+                HStack(spacing: 8) {
+                    Image(systemName: "line.3.horizontal")
+                        .font(.system(size: 10, weight: .bold))
+                    Text(pane.title)
+                        .font(.system(size: 11, weight: .bold, design: .rounded))
+                        .tracking(1.2)
+                        .textCase(.uppercase)
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(NotedTheme.accent, in: RoundedRectangle(cornerRadius: 6))
             }
-            .onDrop(of: [.plainText], isTargeted: nil) { providers in
-                handleDrop(providers: providers, before: true)
+            .onDrop(of: [.utf8PlainText], isTargeted: $headerTargeted) { providers, _ in
+                return loadAndMove(providers: providers, before: true)
             }
-            
+
             // Content
             Group {
                 switch pane {
@@ -713,42 +837,43 @@ struct SidebarPaneWrapper: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .onDrop(of: [.plainText], isTargeted: nil) { providers in
-                handleDrop(providers: providers, before: false)
+            .onDrop(of: [.utf8PlainText], isTargeted: $contentTargeted) { providers, _ in
+                return loadAndMove(providers: providers, before: false)
             }
+
+            // Drop indicator below — visible while hovering over content
+            Rectangle()
+                .fill(NotedTheme.accent)
+                .frame(height: 2)
+                .opacity(contentTargeted ? 1 : 0)
         }
         .background(NotedTheme.panel)
     }
-    
-    private func handleDrop(providers: [NSItemProvider], before: Bool) -> Bool {
+
+    init(pane: SidebarPane, settings: SettingsManager, isLeft: Bool) {
+        self.pane = pane
+        self.settings = settings
+        self.isLeft = isLeft
+    }
+
+    private func loadAndMove(providers: [NSItemProvider], before: Bool) -> Bool {
         guard let provider = providers.first else { return false }
-        
-        provider.loadObject(ofClass: NSString.self) { string, _ in
-            guard let id = string as? String, let draggedPane = SidebarPane(rawValue: id) else { return }
-            
+        provider.loadItem(forTypeIdentifier: "public.utf8-plain-text", options: nil) { item, _ in
+            guard let data = item as? Data,
+                  let id = String(data: data, encoding: .utf8),
+                  let draggedPane = SidebarPane(rawValue: id),
+                  draggedPane != pane else { return }
             DispatchQueue.main.async {
-                var targetArray = isLeft ? appState.settings.leftSidebarPanes : appState.settings.rightSidebarPanes
-                
-                // If dropping on itself, do nothing
-                if draggedPane == pane { return }
-                
-                appState.settings.leftSidebarPanes.removeAll { $0 == draggedPane }
-                appState.settings.rightSidebarPanes.removeAll { $0 == draggedPane }
-                
-                targetArray = isLeft ? appState.settings.leftSidebarPanes : appState.settings.rightSidebarPanes
-                
-                if let currentIndex = targetArray.firstIndex(of: pane) {
-                    let insertIndex = before ? currentIndex : currentIndex + 1
-                    targetArray.insert(draggedPane, at: insertIndex)
+                settings.leftSidebarPanes.removeAll { $0 == draggedPane }
+                settings.rightSidebarPanes.removeAll { $0 == draggedPane }
+                var target = isLeft ? settings.leftSidebarPanes : settings.rightSidebarPanes
+                if let idx = target.firstIndex(of: pane) {
+                    target.insert(draggedPane, at: before ? idx : idx + 1)
                 } else {
-                    targetArray.append(draggedPane)
+                    target.append(draggedPane)
                 }
-                
-                if isLeft {
-                    appState.settings.leftSidebarPanes = targetArray
-                } else {
-                    appState.settings.rightSidebarPanes = targetArray
-                }
+                if isLeft { settings.leftSidebarPanes = target }
+                else { settings.rightSidebarPanes = target }
             }
         }
         return true

--- a/Noted/SettingsManager.swift
+++ b/Noted/SettingsManager.swift
@@ -42,6 +42,14 @@ class SettingsManager: ObservableObject {
     @Published var rightSidebarPanes: [SidebarPane] {
         didSet { save() }
     }
+    /// Persisted pane heights keyed by SidebarPane rawValue, for the left sidebar
+    @Published var leftPaneHeights: [String: CGFloat] {
+        didSet { save() }
+    }
+    /// Persisted pane heights keyed by SidebarPane rawValue, for the right sidebar
+    @Published var rightPaneHeights: [String: CGFloat] {
+        didSet { save() }
+    }
 
     let configPath: String
 
@@ -53,15 +61,19 @@ class SettingsManager: ObservableObject {
         var autoPush: Bool
         var leftSidebarPanes: [SidebarPane]?
         var rightSidebarPanes: [SidebarPane]?
+        var leftPaneHeights: [String: CGFloat]?
+        var rightPaneHeights: [String: CGFloat]?
 
         init(
             onBootCommand: String,
             fileExtensionFilter: String,
-            templatesDirectory: String = "templates",
-            autoSave: Bool = false,
-            autoPush: Bool = false,
-            leftSidebarPanes: [SidebarPane]? = nil,
-            rightSidebarPanes: [SidebarPane]? = nil
+            templatesDirectory: String,
+            autoSave: Bool,
+            autoPush: Bool,
+            leftSidebarPanes: [SidebarPane]?,
+            rightSidebarPanes: [SidebarPane]?,
+            leftPaneHeights: [String: CGFloat]?,
+            rightPaneHeights: [String: CGFloat]?
         ) {
             self.onBootCommand = onBootCommand
             self.fileExtensionFilter = fileExtensionFilter
@@ -70,6 +82,8 @@ class SettingsManager: ObservableObject {
             self.autoPush = autoPush
             self.leftSidebarPanes = leftSidebarPanes
             self.rightSidebarPanes = rightSidebarPanes
+            self.leftPaneHeights = leftPaneHeights
+            self.rightPaneHeights = rightPaneHeights
         }
 
         init(from decoder: Decoder) throws {
@@ -81,6 +95,8 @@ class SettingsManager: ObservableObject {
             autoPush = try container.decodeIfPresent(Bool.self, forKey: .autoPush) ?? false
             leftSidebarPanes = try container.decodeIfPresent([SidebarPane].self, forKey: .leftSidebarPanes)
             rightSidebarPanes = try container.decodeIfPresent([SidebarPane].self, forKey: .rightSidebarPanes)
+            leftPaneHeights = try container.decodeIfPresent([String: CGFloat].self, forKey: .leftPaneHeights)
+            rightPaneHeights = try container.decodeIfPresent([String: CGFloat].self, forKey: .rightPaneHeights)
         }
     }
 
@@ -106,6 +122,8 @@ class SettingsManager: ObservableObject {
             self.autoPush = config.autoPush
             self.leftSidebarPanes = config.leftSidebarPanes ?? [.files, .tags, .links]
             self.rightSidebarPanes = config.rightSidebarPanes ?? [.terminal]
+            self.leftPaneHeights = config.leftPaneHeights ?? [:]
+            self.rightPaneHeights = config.rightPaneHeights ?? [:]
         } else {
             self.onBootCommand = ""
             self.fileExtensionFilter = "*.md, *.txt"
@@ -114,6 +132,8 @@ class SettingsManager: ObservableObject {
             self.autoPush = false
             self.leftSidebarPanes = [.files, .tags, .links]
             self.rightSidebarPanes = [.terminal]
+            self.leftPaneHeights = [:]
+            self.rightPaneHeights = [:]
         }
     }
 
@@ -163,16 +183,14 @@ class SettingsManager: ObservableObject {
             autoSave: autoSave,
             autoPush: autoPush,
             leftSidebarPanes: leftSidebarPanes,
-            rightSidebarPanes: rightSidebarPanes
+            rightSidebarPanes: rightSidebarPanes,
+            leftPaneHeights: leftPaneHeights,
+            rightPaneHeights: rightPaneHeights
         )
-
         guard let data = try? JSONEncoder().encode(config) else { return }
-
-        // Ensure parent directory exists
         let configURL = URL(fileURLWithPath: configPath)
         let parentDir = configURL.deletingLastPathComponent()
         try? FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
-
         try? data.write(to: configURL)
     }
 

--- a/Noted/TagsPaneView.swift
+++ b/Noted/TagsPaneView.swift
@@ -2,54 +2,69 @@ import SwiftUI
 
 struct TagsPaneView: View {
     @EnvironmentObject var appState: AppState
+    @State private var query = ""
+
+    var filteredTags: [(key: String, value: Int)] {
+        let all = appState.allTags().sorted { $0.key < $1.key }
+        guard !query.isEmpty else { return all }
+        return all.filter { $0.key.localizedCaseInsensitiveContains(query) }
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Tags")
-                        .font(.system(size: 11, weight: .bold, design: .rounded))
-                        .tracking(1.8)
-                        .foregroundStyle(NotedTheme.textMuted)
-
-                    Text("All Tags")
-                        .font(.system(size: 18, weight: .bold, design: .rounded))
-                        .foregroundStyle(NotedTheme.textPrimary)
-
-                    let tagCount = appState.allTags().count
-                    if tagCount > 0 {
-                        TinyBadge(text: "\(tagCount) tags")
+        VStack(alignment: .leading, spacing: 0) {
+            // Search bar
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(NotedTheme.textMuted)
+                TextField("Filter tags…", text: $query)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .textFieldStyle(.plain)
+                    .foregroundStyle(NotedTheme.textPrimary)
+                if !query.isEmpty {
+                    Button(action: { query = "" }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(NotedTheme.textMuted)
                     }
+                    .buttonStyle(.plain)
                 }
-
-                Spacer()
             }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(NotedTheme.row)
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(NotedTheme.rowBorder, lineWidth: 1)
+            )
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 8)
 
             Rectangle()
                 .fill(NotedTheme.divider)
                 .frame(height: 1)
 
             ScrollView {
-                let tags = appState.allTags().sorted { $0.key < $1.key }
-                if tags.isEmpty {
+                if filteredTags.isEmpty {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("No tags yet")
+                        Text(query.isEmpty ? "No tags yet" : "No matching tags")
                             .font(.system(size: 13, weight: .semibold, design: .rounded))
                             .foregroundStyle(NotedTheme.textPrimary)
-                        Text("Add tags to your notes using #hashtag syntax.")
+                        Text(query.isEmpty ? "Add tags to your notes using #hashtag syntax." : "Try a different search term.")
                             .font(.system(size: 12, weight: .medium, design: .rounded))
                             .foregroundStyle(NotedTheme.textMuted)
                     }
-                    .padding(.vertical, 4)
+                    .padding(12)
                 } else {
                     VStack(alignment: .leading, spacing: 6) {
-                        ForEach(tags, id: \.key) { tag, count in
+                        ForEach(filteredTags, id: \.key) { tag, count in
                             Button(action: { appState.openTagInNewTab(tag) }) {
                                 HStack(spacing: 8) {
                                     Image(systemName: "number")
                                         .foregroundStyle(NotedTheme.accent)
                                         .frame(width: 16)
-                                    
                                     VStack(alignment: .leading, spacing: 2) {
                                         Text(tag)
                                             .font(.system(size: 13, weight: .semibold, design: .rounded))
@@ -60,7 +75,6 @@ struct TagsPaneView: View {
                                             .foregroundStyle(NotedTheme.textMuted)
                                             .lineLimit(1)
                                     }
-                                    
                                     Spacer()
                                 }
                                 .padding(.horizontal, 8)
@@ -77,10 +91,10 @@ struct TagsPaneView: View {
                             .buttonStyle(.plain)
                         }
                     }
+                    .padding(12)
                 }
             }
         }
-        .padding(12)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }

--- a/NotedTests/AppStateTagTabsTests.swift
+++ b/NotedTests/AppStateTagTabsTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import Noted
+
+/// Tests for tag tab functionality: opening, switching, closing, and MRU cycling with tag tabs
+final class AppStateTagTabsTests: XCTestCase {
+
+    var sut: AppState!
+    var tempDir: URL!
+    var fileA: URL!
+
+    override func setUp() {
+        super.setUp()
+        sut = AppState()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        fileA = tempDir.appendingPathComponent("NoteA.md")
+        try! "Content A".write(to: fileA, atomically: true, encoding: .utf8)
+        sut.rootURL = tempDir
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - TabItem
+
+    func test_tabItem_fileDisplayName_isFilename() {
+        let item = TabItem.file(fileA)
+        XCTAssertEqual(item.displayName, "NoteA.md")
+    }
+
+    func test_tabItem_tagDisplayName_hasPrefixHash() {
+        let item = TabItem.tag("work")
+        XCTAssertEqual(item.displayName, "#work")
+    }
+
+    func test_tabItem_isFile_trueForFile() {
+        XCTAssertTrue(TabItem.file(fileA).isFile)
+        XCTAssertFalse(TabItem.tag("work").isFile)
+    }
+
+    func test_tabItem_isTag_trueForTag() {
+        XCTAssertTrue(TabItem.tag("work").isTag)
+        XCTAssertFalse(TabItem.file(fileA).isTag)
+    }
+
+    func test_tabItem_fileURL_returnsURLForFileTab() {
+        XCTAssertEqual(TabItem.file(fileA).fileURL, fileA)
+        XCTAssertNil(TabItem.tag("work").fileURL)
+    }
+
+    func test_tabItem_tagName_returnsNameForTagTab() {
+        XCTAssertEqual(TabItem.tag("work").tagName, "work")
+        XCTAssertNil(TabItem.file(fileA).tagName)
+    }
+
+    // MARK: - activeTab
+
+    func test_activeTab_nilWhenNoTabs() {
+        XCTAssertNil(sut.activeTab)
+    }
+
+    func test_activeTab_returnsCurrentTabItem() {
+        sut.openFile(fileA)
+        XCTAssertEqual(sut.activeTab, .file(fileA))
+    }
+
+    func test_activeTab_returnsTagTabWhenTagIsActive() {
+        sut.openTagInNewTab("work")
+        XCTAssertEqual(sut.activeTab, .tag("work"))
+    }
+
+    // MARK: - openTagInNewTab
+
+    func test_openTagInNewTab_addsTagTab() {
+        sut.openTagInNewTab("work")
+
+        XCTAssertEqual(sut.tabs.count, 1)
+        XCTAssertEqual(sut.tabs[0], .tag("work"))
+        XCTAssertEqual(sut.activeTabIndex, 0)
+    }
+
+    func test_openTagInNewTab_clearsSelectedFileAndContent() {
+        sut.openFile(fileA)
+        sut.openTagInNewTab("work")
+
+        XCTAssertNil(sut.selectedFile)
+        XCTAssertEqual(sut.fileContent, "")
+        XCTAssertFalse(sut.isDirty)
+    }
+
+    func test_openTagInNewTab_switchesToExistingTabIfAlreadyOpen() {
+        sut.openFile(fileA)
+        sut.openTagInNewTab("work")
+        sut.openTagInNewTab("work") // open again
+
+        XCTAssertEqual(sut.tabs.count, 2, "Should not add duplicate tag tab")
+        XCTAssertEqual(sut.activeTabIndex, 1)
+    }
+
+    func test_openTagInNewTab_mixedWithFileTabs() {
+        sut.openFile(fileA)
+        sut.openTagInNewTab("work")
+
+        XCTAssertEqual(sut.tabs.count, 2)
+        XCTAssertEqual(sut.tabs[0], .file(fileA))
+        XCTAssertEqual(sut.tabs[1], .tag("work"))
+        XCTAssertEqual(sut.activeTabIndex, 1)
+    }
+
+    func test_openTagInNewTab_multipleDistinctTags() {
+        sut.openTagInNewTab("work")
+        sut.openTagInNewTab("ideas")
+
+        XCTAssertEqual(sut.tabs.count, 2)
+        XCTAssertEqual(sut.tabs[0], .tag("work"))
+        XCTAssertEqual(sut.tabs[1], .tag("ideas"))
+    }
+
+    // MARK: - Closing tag tabs
+
+    func test_closeTagTab_removesItAndFocusesNeighbor() {
+        sut.openFile(fileA)
+        sut.openTagInNewTab("work")
+
+        sut.closeTab(at: 1)
+
+        XCTAssertEqual(sut.tabs.count, 1)
+        XCTAssertEqual(sut.tabs[0], .file(fileA))
+        XCTAssertEqual(sut.activeTabIndex, 0)
+        XCTAssertEqual(sut.selectedFile, fileA)
+    }
+
+    func test_closeTagTab_whenLastTab_clearsState() {
+        sut.openTagInNewTab("work")
+
+        sut.closeTab(at: 0)
+
+        XCTAssertTrue(sut.tabs.isEmpty)
+        XCTAssertNil(sut.activeTabIndex)
+        XCTAssertNil(sut.selectedFile)
+    }
+
+    // MARK: - Reopening closed tag tabs
+
+    func test_reopenLastClosedTab_restoresTagTab() {
+        sut.openTagInNewTab("work")
+        sut.closeTab(at: 0)
+
+        sut.reopenLastClosedTab()
+
+        XCTAssertEqual(sut.tabs.count, 1)
+        XCTAssertEqual(sut.tabs[0], .tag("work"))
+        XCTAssertEqual(sut.activeTabIndex, 0)
+    }
+
+    // MARK: - MRU cycling with tag tabs
+
+    func test_cycleMostRecentTabs_cyclesBetweenFileAndTagTab() {
+        sut.openFile(fileA)       // MRU: [A]
+        sut.openTagInNewTab("work") // MRU: [work, A]
+        sut.switchTab(to: 0)       // MRU: [A, work]
+
+        sut.cycleMostRecentTabs()
+
+        XCTAssertEqual(sut.activeTab, .tag("work"))
+    }
+
+    func test_cycleMostRecentTabs_togglingBetweenFileAndTagTab() {
+        sut.openFile(fileA)
+        sut.openTagInNewTab("work")
+        sut.switchTab(to: 0) // switch to fileA
+
+        sut.cycleMostRecentTabs() // → work
+        XCTAssertEqual(sut.activeTab, .tag("work"))
+
+        sut.cycleMostRecentTabs() // → fileA
+        XCTAssertEqual(sut.activeTab, .file(fileA))
+    }
+}

--- a/NotedTests/FileTreeHiddenItemsTests.swift
+++ b/NotedTests/FileTreeHiddenItemsTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import Noted
+
+/// Tests for buildFileTree hidden item filtering: dot-folders visible, .git excluded, dot-files excluded
+final class FileTreeHiddenItemsTests: XCTestCase {
+
+    var vaultDir: URL!
+    var settingsDir: URL!
+    var settings: SettingsManager!
+
+    override func setUp() {
+        super.setUp()
+        let base = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        vaultDir = base.appendingPathComponent("vault", isDirectory: true)
+        settingsDir = base.appendingPathComponent("settings", isDirectory: true)
+        try! FileManager.default.createDirectory(at: vaultDir, withIntermediateDirectories: true)
+        try! FileManager.default.createDirectory(at: settingsDir, withIntermediateDirectories: true)
+        settings = SettingsManager(configPath: settingsDir.appendingPathComponent("settings.json").path)
+        settings.fileExtensionFilter = "*" // show all file types
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: vaultDir.deletingLastPathComponent())
+        settings = nil
+        super.tearDown()
+    }
+
+    // MARK: - Dot-folders
+
+    func test_buildFileTree_showsDotPrefixedFolders() {
+        createDir(".obsidian")
+        createDir("notes")
+
+        let nodes = buildFileTree(at: vaultDir, sortCriterion: .name, ascending: true, settings: settings)
+        let names = nodes.map(\.name)
+
+        XCTAssertTrue(names.contains(".obsidian"), "Dot-prefixed folders should appear in tree")
+        XCTAssertTrue(names.contains("notes"))
+    }
+
+    func test_buildFileTree_excludesGitFolder() {
+        createDir(".git")
+        createDir("notes")
+
+        let nodes = buildFileTree(at: vaultDir, sortCriterion: .name, ascending: true, settings: settings)
+        let names = nodes.map(\.name)
+
+        XCTAssertFalse(names.contains(".git"), ".git folder should be excluded from tree")
+        XCTAssertTrue(names.contains("notes"))
+    }
+
+    func test_buildFileTree_showsNestedContentInsideDotFolder() {
+        createDir(".obsidian")
+        createFile(at: ".obsidian/config.json", contents: "{}")
+
+        let nodes = buildFileTree(at: vaultDir, sortCriterion: .name, ascending: true, settings: settings)
+        let obsidianNode = nodes.first { $0.name == ".obsidian" }
+
+        XCTAssertNotNil(obsidianNode, ".obsidian folder should be present")
+        XCTAssertEqual(obsidianNode?.children?.count, 1, "Contents of dot-folder should be listed")
+    }
+
+    // MARK: - Dot-files
+
+    func test_buildFileTree_excludesDotFiles() {
+        createFile(at: ".DS_Store", contents: "")
+        createFile(at: "note.md", contents: "")
+
+        let nodes = buildFileTree(at: vaultDir, sortCriterion: .name, ascending: true, settings: settings)
+        let names = nodes.map(\.name)
+
+        XCTAssertFalse(names.contains(".DS_Store"), "Dot-files should be excluded")
+        XCTAssertTrue(names.contains("note.md"))
+    }
+
+    func test_buildFileTree_excludesDotPrefixedFiles() {
+        createFile(at: ".hidden-note.md", contents: "")
+        createFile(at: "visible.md", contents: "")
+
+        let nodes = buildFileTree(at: vaultDir, sortCriterion: .name, ascending: true, settings: settings)
+        let names = nodes.map(\.name)
+
+        XCTAssertFalse(names.contains(".hidden-note.md"), "Dot-prefixed files should be excluded")
+        XCTAssertTrue(names.contains("visible.md"))
+    }
+
+    // MARK: - Empty vault
+
+    func test_buildFileTree_emptyDirectory_returnsEmpty() {
+        let nodes = buildFileTree(at: vaultDir, sortCriterion: .name, ascending: true, settings: settings)
+        XCTAssertTrue(nodes.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func createDir(_ name: String) -> URL {
+        let url = vaultDir.appendingPathComponent(name, isDirectory: true)
+        try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @discardableResult
+    private func createFile(at relativePath: String, contents: String) -> URL {
+        let url = vaultDir.appendingPathComponent(relativePath)
+        let dir = url.deletingLastPathComponent()
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try! contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}

--- a/NotedTests/SettingsManagerTests.swift
+++ b/NotedTests/SettingsManagerTests.swift
@@ -276,6 +276,64 @@ final class SettingsManagerTests: XCTestCase {
         cancellable.cancel()
     }
 
+    // MARK: - Sidebar Panes
+
+    func test_initialState_defaultSidebarPanes() {
+        XCTAssertEqual(sut.leftSidebarPanes, [.files, .tags, .links])
+        XCTAssertEqual(sut.rightSidebarPanes, [.terminal])
+    }
+
+    func test_leftSidebarPanes_canBeModified() {
+        sut.leftSidebarPanes = [.files]
+        XCTAssertEqual(sut.leftSidebarPanes, [.files])
+    }
+
+    func test_rightSidebarPanes_canBeModified() {
+        sut.rightSidebarPanes = [.links, .tags]
+        XCTAssertEqual(sut.rightSidebarPanes, [.links, .tags])
+    }
+
+    func test_sidebarPanes_persistToDisk() {
+        sut.leftSidebarPanes = [.tags, .files]
+        sut.rightSidebarPanes = [.links]
+
+        let newManager = SettingsManager(configPath: configFilePath)
+        XCTAssertEqual(newManager.leftSidebarPanes, [.tags, .files])
+        XCTAssertEqual(newManager.rightSidebarPanes, [.links])
+    }
+
+    func test_sidebarPanes_movingPaneFromLeftToRight() {
+        // Start: left=[files, tags, links], right=[terminal]
+        sut.leftSidebarPanes.removeAll { $0 == .links }
+        sut.rightSidebarPanes.append(.links)
+
+        XCTAssertFalse(sut.leftSidebarPanes.contains(.links))
+        XCTAssertTrue(sut.rightSidebarPanes.contains(.links))
+    }
+
+    func test_sidebarPanes_emptyLeftPanes_persistAndLoad() {
+        sut.leftSidebarPanes = []
+
+        let newManager = SettingsManager(configPath: configFilePath)
+        XCTAssertEqual(newManager.leftSidebarPanes, [])
+    }
+
+    func test_load_missingSidebarPanesUsesDefaults() {
+        let config: [String: Any] = [
+            "onBootCommand": "",
+            "fileExtensionFilter": "*.md, *.txt",
+            "templatesDirectory": "templates",
+            "autoSave": false,
+            "autoPush": false
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: config)
+        try! data.write(to: URL(fileURLWithPath: configFilePath))
+
+        let newManager = SettingsManager(configPath: configFilePath)
+        XCTAssertEqual(newManager.leftSidebarPanes, [.files, .tags, .links])
+        XCTAssertEqual(newManager.rightSidebarPanes, [.terminal])
+    }
+
     // MARK: - Default Config Path
 
     func test_defaultConfigPath_inApplicationSupport() {


### PR DESCRIPTION
## Summary

![CleanShot 2026-03-12 at 05 20 38](https://github.com/user-attachments/assets/b079c019-9f35-4ef6-bcf0-c5800954a69a)


- Introduces a `SidebarPane` enum (`.files`, `.tags`, `.links`, `.terminal`) with user-configurable left/right sidebar assignments persisted to `settings.json`
- `SidebarContainerView` renders each sidebar from an ordered list of panes; panes can be dragged between sidebars and reordered via `NSItemProvider`-based drag-and-drop with live drop-indicator lines
- `ResizeDivider` between panes supports drag-to-resize with `NSCursor.resizeUpDown` hover feedback; heights are persisted per-pane and reset automatically when pane order changes
- Removes the old `isRelatedPaneVisible` toolbar toggle in favour of the new modular layout

## Tests

272 tests, 0 failures.