### PR TITLE
feat: use .noted for app settings sync

### DIFF
--- a/.agents/REPO_RULES.md
+++ b/.agents/REPO_RULES.md
@@ -67,7 +67,7 @@ spctl --assess --type execute --verbose=4 "/tmp/Synapse.xcarchive/Products/Appli
 | `SearchView.swift` | In-file search (CMD-F) and all-files search (CMD-Shift-F). |
 | `TerminalPaneView.swift` | Embedded terminal pane (right sidebar). |
 | `GitService.swift` | Shell-out wrapper around git CLI. |
-| `SettingsManager.swift` | JSON-persisted settings (auto-save, auto-push, file extension filter, on-boot command). Config file at `~/Library/Application Support/Synapse/settings.json`. |
+| `SettingsManager.swift` | JSON/YAML-persisted settings (auto-save, auto-push, file extension filter, on-boot command). Machine-local config file at `~/Library/Application Support/Synapse/settings.yml`; vault config file at `.noted/settings.yml`. |
 | `Theme.swift` | All colors, button styles, and shared UI components (`SynapseTheme`, `ChromeButtonStyle`, `PrimaryChromeButtonStyle`, `TinyBadge`, `PanelSurface`). |
 | `SynapseApp.swift` | App entry point. |
 

--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ Drag and drop panes between left and right sidebars:
 - **Gist Publishing** - Publish notes to GitHub Gists (requires GitHub PAT)
 
 ### Vault-Specific Settings
-Settings automatically sync with your vault. When you open a vault, Synapse stores its settings in a `.noted` folder at the vault root:
+Settings automatically sync with your vault. When you open a vault, Synapse stores its settings in `.noted/settings.yml` at the vault root:
 - Settings travel with the vault — perfect for syncing via Git or cloud storage
 - Each vault has its own independent settings
 - The `.noted` folder is visible in the file tree and can be committed to version control
-- Your GitHub Personal Access Token stays local (never leaves your machine)
+- Your GitHub Personal Access Token stays local in `~/Library/Application Support/Synapse/settings.yml` (never leaves your machine)
 
 ## Keyboard Shortcuts
 

--- a/Synapse.xcodeproj/project.pbxproj
+++ b/Synapse.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		70792E277639E834624DC380 /* SplitPaneKeyboardAndCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B5194AC3C7EE4980499F00 /* SplitPaneKeyboardAndCursorTests.swift */; };
 		716F196A70B019DB1125E38F /* AppStateCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56691DF2CDDFA2DF5F263CF3 /* AppStateCoreTests.swift */; };
 		726A539D32A11574BB72A17D /* AppStateExitVaultFullTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490C9CA7FD044A526559CA53 /* AppStateExitVaultFullTests.swift */; };
+		7371C3F9A6EADA8C24730961 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 09980A02177F156C0F1B20D8 /* Yams */; };
 		7FA55FF63CB1CC6E03BEEBCE /* AppStateWikiLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0502C0261847F74C47B810 /* AppStateWikiLinkTests.swift */; };
 		84CE3D3A60AFCABF88D62FFC /* AppStateSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A600692EB7955AD6BF962D /* AppStateSearchTests.swift */; };
 		8777D23DB72BE7ADC588DB22 /* AppStateFolderOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 581F07CA2599C2ED63315D92 /* AppStateFolderOperationsTests.swift */; };
@@ -175,6 +176,7 @@
 			files = (
 				89E3EA85538AA25FAAB34501 /* SwiftTerm in Frameworks */,
 				3A7ED42BFA879ABEA38CD06D /* Grape in Frameworks */,
+				7371C3F9A6EADA8C24730961 /* Yams in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -304,6 +306,7 @@
 			packageProductDependencies = (
 				C4C7BBA308D786C6CE2F1328 /* SwiftTerm */,
 				E3D1D630282C1FE7995BB335 /* Grape */,
+				09980A02177F156C0F1B20D8 /* Yams */,
 			);
 			productName = Synapse;
 			productReference = 12B05C011702D5236468CEDD /* Synapse.app */;
@@ -350,6 +353,7 @@
 			packageReferences = (
 				DBB92F75A673FD80649EA29B /* XCRemoteSwiftPackageReference "Grape" */,
 				CCDCD6E4B4DBBC00978D8C93 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
+				14519BB0FD8BF9DAF35FBD70 /* XCRemoteSwiftPackageReference "Yams" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 8B9CF596FCB07B1002F10E36 /* Products */;
@@ -701,6 +705,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		14519BB0FD8BF9DAF35FBD70 /* XCRemoteSwiftPackageReference "Yams" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jpsim/Yams";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.2.1;
+			};
+		};
 		CCDCD6E4B4DBBC00978D8C93 /* XCRemoteSwiftPackageReference "SwiftTerm" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/migueldeicaza/SwiftTerm";
@@ -720,6 +732,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		09980A02177F156C0F1B20D8 /* Yams */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 14519BB0FD8BF9DAF35FBD70 /* XCRemoteSwiftPackageReference "Yams" */;
+			productName = Yams;
+		};
 		C4C7BBA308D786C6CE2F1328 /* SwiftTerm */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CCDCD6E4B4DBBC00978D8C93 /* XCRemoteSwiftPackageReference "SwiftTerm" */;

--- a/Synapse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Synapse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "acc8f30995e79a3a69a8bec5f5d9e32f9591b40d7c8ba11e3f3d247d6b221080",
+  "originHash" : "523b15750156f082d377234544c9aba6546942c392dfe16ad1771dc797d5de59",
   "pins" : [
     {
       "identity" : "grape",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "b1262db5b6bea699a8260a8c66999436c508ca56",
         "version" : "1.11.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
+        "version" : "6.2.1"
       }
     }
   ],

--- a/Synapse/AppState.swift
+++ b/Synapse/AppState.swift
@@ -198,7 +198,7 @@ class AppState: ObservableObject {
     @AppStorage("sortAscending") var sortAscending: Bool = true
 
     // Settings
-    var settings: SettingsManager
+    @Published var settings: SettingsManager
     let gistPublisher = GistPublisher()
 
     /// Replace settings for testing purposes only

--- a/Synapse/SettingsManager.swift
+++ b/Synapse/SettingsManager.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Combine
+import Yams
 
 enum SidebarPane: String, Codable, CaseIterable, Identifiable {
     case files = "files"
@@ -23,6 +24,9 @@ enum SidebarPane: String, Codable, CaseIterable, Identifiable {
 
 /// Manages application settings with persistence to a local JSON config file
 class SettingsManager: ObservableObject {
+    private static let vaultSettingsFilename = "settings.yml"
+    private static let globalSettingsFilename = "settings.yml"
+
     @Published var onBootCommand: String {
         didSet { save() }
     }
@@ -189,12 +193,6 @@ class SettingsManager: ObservableObject {
         var dailyNotesOpenOnStartup: Bool?
         var autoSave: Bool
         var autoPush: Bool
-        var leftSidebarPanes: [SidebarPane]?
-        var rightSidebarPanes: [SidebarPane]?
-        var leftPaneHeights: [String: CGFloat]?
-        var rightPaneHeights: [String: CGFloat]?
-        var collapsedPanes: [String]?
-        var fileTreeMode: String?
         var pinnedItems: [PinnedItem]?
 
         init(
@@ -208,12 +206,6 @@ class SettingsManager: ObservableObject {
             dailyNotesOpenOnStartup: Bool?,
             autoSave: Bool,
             autoPush: Bool,
-            leftSidebarPanes: [SidebarPane]?,
-            rightSidebarPanes: [SidebarPane]?,
-            leftPaneHeights: [String: CGFloat]?,
-            rightPaneHeights: [String: CGFloat]?,
-            collapsedPanes: [String]?,
-            fileTreeMode: String?,
             pinnedItems: [PinnedItem]?
         ) {
             self.onBootCommand = onBootCommand
@@ -226,12 +218,6 @@ class SettingsManager: ObservableObject {
             self.dailyNotesOpenOnStartup = dailyNotesOpenOnStartup
             self.autoSave = autoSave
             self.autoPush = autoPush
-            self.leftSidebarPanes = leftSidebarPanes
-            self.rightSidebarPanes = rightSidebarPanes
-            self.leftPaneHeights = leftPaneHeights
-            self.rightPaneHeights = rightPaneHeights
-            self.collapsedPanes = collapsedPanes
-            self.fileTreeMode = fileTreeMode
             self.pinnedItems = pinnedItems
         }
 
@@ -247,22 +233,36 @@ class SettingsManager: ObservableObject {
             dailyNotesOpenOnStartup = try container.decodeIfPresent(Bool.self, forKey: .dailyNotesOpenOnStartup)
             autoSave = try container.decodeIfPresent(Bool.self, forKey: .autoSave) ?? false
             autoPush = try container.decodeIfPresent(Bool.self, forKey: .autoPush) ?? false
-            leftSidebarPanes = try container.decodeIfPresent([SidebarPane].self, forKey: .leftSidebarPanes)
-            rightSidebarPanes = try container.decodeIfPresent([SidebarPane].self, forKey: .rightSidebarPanes)
-            leftPaneHeights = try container.decodeIfPresent([String: CGFloat].self, forKey: .leftPaneHeights)
-            rightPaneHeights = try container.decodeIfPresent([String: CGFloat].self, forKey: .rightPaneHeights)
-            collapsedPanes = try container.decodeIfPresent([String].self, forKey: .collapsedPanes)
-            fileTreeMode = try container.decodeIfPresent(String.self, forKey: .fileTreeMode)
             pinnedItems = try container.decodeIfPresent([PinnedItem].self, forKey: .pinnedItems)
         }
     }
 
-    /// Config for global/sensitive settings only
+    /// Config for machine-local settings only
     private struct GlobalConfig: Codable {
         var githubPAT: String?
+        var leftSidebarPanes: [SidebarPane]?
+        var rightSidebarPanes: [SidebarPane]?
+        var leftPaneHeights: [String: CGFloat]?
+        var rightPaneHeights: [String: CGFloat]?
+        var collapsedPanes: [String]?
+        var fileTreeMode: String?
 
-        init(githubPAT: String?) {
+        init(
+            githubPAT: String?,
+            leftSidebarPanes: [SidebarPane]?,
+            rightSidebarPanes: [SidebarPane]?,
+            leftPaneHeights: [String: CGFloat]?,
+            rightPaneHeights: [String: CGFloat]?,
+            collapsedPanes: [String]?,
+            fileTreeMode: String?
+        ) {
             self.githubPAT = githubPAT
+            self.leftSidebarPanes = leftSidebarPanes
+            self.rightSidebarPanes = rightSidebarPanes
+            self.leftPaneHeights = leftPaneHeights
+            self.rightPaneHeights = rightPaneHeights
+            self.collapsedPanes = collapsedPanes
+            self.fileTreeMode = fileTreeMode
         }
     }
 
@@ -271,7 +271,7 @@ class SettingsManager: ObservableObject {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         let configDir = appSupport.appendingPathComponent("Synapse")
         try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
-        let configPath = configDir.appendingPathComponent("settings.json").path
+        let configPath = configDir.appendingPathComponent(Self.globalSettingsFilename).path
         self.init(configPath: configPath)
     }
 
@@ -323,7 +323,7 @@ class SettingsManager: ObservableObject {
         }
     }
 
-    /// Initialize with vault root - stores settings in .noted/settings.json
+    /// Initialize with vault root - stores settings in .noted/settings.yml
     /// - Parameters:
     ///   - vaultRoot: The vault root URL (nil means use defaults)
     ///   - globalConfigPath: Optional path for global/sensitive settings (defaults to Application Support)
@@ -331,7 +331,7 @@ class SettingsManager: ObservableObject {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         let configDir = appSupport.appendingPathComponent("Synapse")
         try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
-        let defaultGlobalPath = configDir.appendingPathComponent("settings.json").path
+        let defaultGlobalPath = configDir.appendingPathComponent(Self.globalSettingsFilename).path
 
         self.init(
             vaultRoot: vaultRoot,
@@ -341,13 +341,13 @@ class SettingsManager: ObservableObject {
 
     /// Full initializer with vault root and global config path
     init(vaultRoot: URL?, globalConfigPath: String) {
-        self.configPath = vaultRoot?.appendingPathComponent(".noted/settings.json").path ?? globalConfigPath
+        self.configPath = vaultRoot?.appendingPathComponent(".noted/\(Self.vaultSettingsFilename)").path ?? globalConfigPath
         self.vaultRootURL = vaultRoot
         self.globalConfigPath = globalConfigPath
 
         if let vaultRoot = vaultRoot {
             // Vault mode: load from both vault config and global config
-            let vaultConfigPath = vaultRoot.appendingPathComponent(".noted/settings.json").path
+            let vaultConfigPath = vaultRoot.appendingPathComponent(".noted/\(Self.vaultSettingsFilename)").path
 
             // Create .noted folder and settings file if they don't exist
             let notedDir = vaultRoot.appendingPathComponent(".noted")
@@ -367,12 +367,6 @@ class SettingsManager: ObservableObject {
                 self.dailyNotesOpenOnStartup = vaultConfig.dailyNotesOpenOnStartup ?? false
                 self.autoSave = vaultConfig.autoSave
                 self.autoPush = vaultConfig.autoPush
-                self.leftSidebarPanes = vaultConfig.leftSidebarPanes ?? [.files, .tags, .links]
-                self.rightSidebarPanes = vaultConfig.rightSidebarPanes ?? [.terminal]
-                self.leftPaneHeights = vaultConfig.leftPaneHeights ?? [:]
-                self.rightPaneHeights = vaultConfig.rightPaneHeights ?? [:]
-                self.collapsedPanes = Set(vaultConfig.collapsedPanes ?? [])
-                self.fileTreeMode = FileTreeMode(rawValue: vaultConfig.fileTreeMode ?? "") ?? .folder
                 self.pinnedItems = vaultConfig.pinnedItems ?? []
             } else {
                 // No vault config exists yet - use defaults
@@ -386,18 +380,25 @@ class SettingsManager: ObservableObject {
                 self.dailyNotesOpenOnStartup = false
                 self.autoSave = false
                 self.autoPush = false
-                self.leftSidebarPanes = [.files, .tags, .links]
-                self.rightSidebarPanes = [.terminal]
-                self.leftPaneHeights = [:]
-                self.rightPaneHeights = [:]
-                self.collapsedPanes = []
-                self.fileTreeMode = .folder
                 self.pinnedItems = []
             }
 
-            // Load global/sensitive settings
+            self.leftSidebarPanes = [.files, .tags, .links]
+            self.rightSidebarPanes = [.terminal]
+            self.leftPaneHeights = [:]
+            self.rightPaneHeights = [:]
+            self.collapsedPanes = []
+            self.fileTreeMode = .folder
+
+            // Load global/machine-local settings
             if let globalConfig = Self.loadGlobalConfig(from: globalConfigPath) {
                 self.githubPAT = globalConfig.githubPAT ?? ""
+                self.leftSidebarPanes = globalConfig.leftSidebarPanes ?? self.leftSidebarPanes
+                self.rightSidebarPanes = globalConfig.rightSidebarPanes ?? self.rightSidebarPanes
+                self.leftPaneHeights = globalConfig.leftPaneHeights ?? self.leftPaneHeights
+                self.rightPaneHeights = globalConfig.rightPaneHeights ?? self.rightPaneHeights
+                self.collapsedPanes = Set(globalConfig.collapsedPanes ?? Array(self.collapsedPanes))
+                self.fileTreeMode = FileTreeMode(rawValue: globalConfig.fileTreeMode ?? "") ?? self.fileTreeMode
             } else {
                 self.githubPAT = ""
             }
@@ -531,13 +532,14 @@ class SettingsManager: ObservableObject {
                 fileTreeMode: fileTreeMode.rawValue,
                 pinnedItems: pinnedItems.isEmpty ? nil : pinnedItems
             )
-            guard let data = try? JSONEncoder().encode(config) else { return }
+            let encoder = Self.makePrettyJSONEncoder()
+            guard let data = try? encoder.encode(config) else { return }
             let configURL = URL(fileURLWithPath: configPath)
             let parentDir = configURL.deletingLastPathComponent()
             try? FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
             try? data.write(to: configURL)
         } else if let vaultRootURL = vaultRootURL {
-            // Vault mode: save vault settings to .noted/settings.json
+            // Vault mode: save vault settings to .noted/settings.yml
             let vaultConfig = VaultConfig(
                 onBootCommand: onBootCommand,
                 fileExtensionFilter: fileExtensionFilter,
@@ -549,31 +551,33 @@ class SettingsManager: ObservableObject {
                 dailyNotesOpenOnStartup: dailyNotesOpenOnStartup,
                 autoSave: autoSave,
                 autoPush: autoPush,
-                leftSidebarPanes: leftSidebarPanes,
-                rightSidebarPanes: rightSidebarPanes,
-                leftPaneHeights: leftPaneHeights,
-                rightPaneHeights: rightPaneHeights,
-                collapsedPanes: Array(collapsedPanes),
-                fileTreeMode: fileTreeMode.rawValue,
                 pinnedItems: pinnedItems.isEmpty ? nil : pinnedItems
             )
 
-            // Save vault-specific settings to .noted/settings.json
+            // Save vault-specific settings to .noted/settings.yml
             let notedDir = vaultRootURL.appendingPathComponent(".noted")
             try? FileManager.default.createDirectory(at: notedDir, withIntermediateDirectories: true)
-            let vaultConfigPath = notedDir.appendingPathComponent("settings.json")
+            let vaultConfigPath = notedDir.appendingPathComponent(Self.vaultSettingsFilename)
 
-            guard let vaultData = try? JSONEncoder().encode(vaultConfig) else { return }
-            try? vaultData.write(to: vaultConfigPath)
+            guard let vaultYAML = try? YAMLEncoder().encode(vaultConfig) else { return }
+            try? vaultYAML.write(to: vaultConfigPath, atomically: true, encoding: .utf8)
 
-            // Save sensitive settings to global config
+            // Save machine-local settings to global config
             if let globalConfigPath = globalConfigPath {
-                let globalConfig = GlobalConfig(githubPAT: githubPAT.isEmpty ? nil : githubPAT)
-                guard let globalData = try? JSONEncoder().encode(globalConfig) else { return }
+                let globalConfig = GlobalConfig(
+                    githubPAT: githubPAT.isEmpty ? nil : githubPAT,
+                    leftSidebarPanes: leftSidebarPanes,
+                    rightSidebarPanes: rightSidebarPanes,
+                    leftPaneHeights: leftPaneHeights,
+                    rightPaneHeights: rightPaneHeights,
+                    collapsedPanes: Array(collapsedPanes),
+                    fileTreeMode: fileTreeMode.rawValue
+                )
+                guard let globalYAML = try? YAMLEncoder().encode(globalConfig) else { return }
                 let globalConfigURL = URL(fileURLWithPath: globalConfigPath)
                 let globalParentDir = globalConfigURL.deletingLastPathComponent()
                 try? FileManager.default.createDirectory(at: globalParentDir, withIntermediateDirectories: true)
-                try? globalData.write(to: globalConfigURL)
+                try? globalYAML.write(to: globalConfigURL, atomically: true, encoding: .utf8)
             }
         }
         // If no vault and not legacy mode, don't save anything (use defaults in memory)
@@ -592,11 +596,11 @@ class SettingsManager: ObservableObject {
     /// Load vault-specific config from disk
     private static func loadVaultConfig(from path: String) -> VaultConfig? {
         guard FileManager.default.fileExists(atPath: path),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+              let yaml = try? String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8) else {
             return nil
         }
 
-        return try? JSONDecoder().decode(VaultConfig.self, from: data)
+        return try? YAMLDecoder().decode(VaultConfig.self, from: yaml)
     }
 
     /// Load global/sensitive config from disk
@@ -606,6 +610,18 @@ class SettingsManager: ObservableObject {
             return nil
         }
 
+        if let yaml = String(data: data, encoding: .utf8),
+           let config = try? YAMLDecoder().decode(GlobalConfig.self, from: yaml) {
+            return config
+        }
+
         return try? JSONDecoder().decode(GlobalConfig.self, from: data)
+    }
+
+    /// Create a JSON encoder with pretty printing enabled
+    private static func makePrettyJSONEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
     }
 }

--- a/SynapseTests/SettingsManagerTests.swift
+++ b/SynapseTests/SettingsManagerTests.swift
@@ -401,13 +401,14 @@ final class SettingsManagerTests: XCTestCase {
     func test_defaultConfigPath_inApplicationSupport() {
         let manager = SettingsManager()
         let expectedPath = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("Synapse/settings.json")
+            .appendingPathComponent("Synapse/settings.yml")
             .path
 
         // This is a bit of a hack since we can't easily test the default init without mocking
         // but we can at least verify the default path pattern
         XCTAssertTrue(manager.configPath.contains("Synapse"), "Default config path should be in Application Support/Synapse")
-        XCTAssertTrue(manager.configPath.hasSuffix(".json"), "Default config should be JSON file")
+        XCTAssertEqual(manager.configPath, expectedPath)
+        XCTAssertTrue(manager.configPath.hasSuffix(".yml"), "Default config should be YAML file")
     }
 
     // MARK: - Graph Pane
@@ -455,14 +456,14 @@ final class SettingsManagerTests: XCTestCase {
 
         // Verify the settings file was created in .noted folder
         let notedDir = vaultDir.appendingPathComponent(".noted", isDirectory: true)
-        let settingsFile = notedDir.appendingPathComponent("settings.json")
+        let settingsFile = notedDir.appendingPathComponent("settings.yml")
         XCTAssertTrue(FileManager.default.fileExists(atPath: settingsFile.path),
                       "Settings file should be created in .noted folder")
 
         // Create new manager pointing to same vault and verify settings persisted
         let newManager = SettingsManager(vaultRoot: vaultDir)
         XCTAssertEqual(newManager.fileExtensionFilter, "*.swift",
-                       "Settings should persist to .noted/settings.json")
+                       "Settings should persist to .noted/settings.yml")
     }
 
     func test_vaultSpecificSettings_createsNotedFolderAutomatically() {
@@ -488,7 +489,7 @@ final class SettingsManagerTests: XCTestCase {
         // Create a separate Application Support config file for testing
         let appSupportDir = tempDir.appendingPathComponent("AppSupport", isDirectory: true)
         try! FileManager.default.createDirectory(at: appSupportDir, withIntermediateDirectories: true)
-        let globalConfigPath = appSupportDir.appendingPathComponent("settings.json").path
+        let globalConfigPath = appSupportDir.appendingPathComponent("settings.yml").path
 
         // Initialize manager with both vault root and global config path
         var manager = SettingsManager(vaultRoot: vaultDir, globalConfigPath: globalConfigPath)
@@ -497,17 +498,99 @@ final class SettingsManagerTests: XCTestCase {
         manager.githubPAT = "ghp_test_token"
 
         // Verify token was saved to global config, not vault config
-        let notedSettingsFile = vaultDir.appendingPathComponent(".noted/settings.json")
-        let globalData = try! Data(contentsOf: URL(fileURLWithPath: globalConfigPath))
-        let globalJson = try! JSONSerialization.jsonObject(with: globalData) as! [String: Any]
-        XCTAssertEqual(globalJson["githubPAT"] as? String, "ghp_test_token",
-                       "githubPAT should be saved to global config")
+        let notedSettingsFile = vaultDir.appendingPathComponent(".noted/settings.yml")
+        let globalText = try! String(contentsOfFile: globalConfigPath, encoding: .utf8)
+        XCTAssertTrue(globalText.contains("githubPAT:"))
+        XCTAssertTrue(globalText.contains("ghp_test_token"),
+                      "githubPAT should be saved to global config")
 
         // Verify token is NOT in vault config
-        let vaultData = try! Data(contentsOf: notedSettingsFile)
-        let vaultJson = try! JSONSerialization.jsonObject(with: vaultData) as! [String: Any]
-        XCTAssertNil(vaultJson["githubPAT"],
-                     "githubPAT should NOT be saved to vault-specific config")
+        let vaultText = try! String(contentsOf: notedSettingsFile, encoding: .utf8)
+        XCTAssertFalse(vaultText.contains("githubPAT:"),
+                       "githubPAT should NOT be saved to vault-specific config")
+    }
+
+    func test_vaultSpecificSettings_layoutSettingsStayInApplicationSupport() {
+        let vaultDir = tempDir.appendingPathComponent("TestVault", isDirectory: true)
+        try! FileManager.default.createDirectory(at: vaultDir, withIntermediateDirectories: true)
+
+        let appSupportDir = tempDir.appendingPathComponent("AppSupport", isDirectory: true)
+        try! FileManager.default.createDirectory(at: appSupportDir, withIntermediateDirectories: true)
+        let globalConfigPath = appSupportDir.appendingPathComponent("settings.yml").path
+
+        let manager = SettingsManager(vaultRoot: vaultDir, globalConfigPath: globalConfigPath)
+        manager.leftSidebarPanes = [.files, .links]
+        manager.rightSidebarPanes = [.terminal, .tags]
+        manager.leftPaneHeights = [:]
+        manager.rightPaneHeights = [:]
+        manager.collapsedPanes = []
+        manager.fileTreeMode = .folder
+
+        let vaultText = try! String(contentsOf: vaultDir.appendingPathComponent(".noted/settings.yml"), encoding: .utf8)
+        let globalText = try! String(contentsOfFile: globalConfigPath, encoding: .utf8)
+
+        XCTAssertFalse(vaultText.contains("leftSidebarPanes:"))
+        XCTAssertFalse(vaultText.contains("rightSidebarPanes:"))
+        XCTAssertFalse(vaultText.contains("leftPaneHeights:"))
+        XCTAssertFalse(vaultText.contains("rightPaneHeights:"))
+        XCTAssertFalse(vaultText.contains("collapsedPanes:"))
+        XCTAssertFalse(vaultText.contains("fileTreeMode:"))
+
+        XCTAssertTrue(globalText.contains("leftSidebarPanes:"))
+        XCTAssertTrue(globalText.contains("- files"))
+        XCTAssertTrue(globalText.contains("- links"))
+        XCTAssertTrue(globalText.contains("rightSidebarPanes:"))
+        XCTAssertTrue(globalText.contains("- terminal"))
+        XCTAssertTrue(globalText.contains("- tags"))
+        XCTAssertTrue(globalText.contains("leftPaneHeights: {}"))
+        XCTAssertTrue(globalText.contains("rightPaneHeights: {}"))
+        XCTAssertTrue(globalText.contains("collapsedPanes: []"))
+        XCTAssertTrue(globalText.contains("fileTreeMode: folder"))
+    }
+
+    func test_vaultSpecificSettings_loadsLayoutSettingsFromGlobalConfig() {
+        let vaultDir = tempDir.appendingPathComponent("LayoutVault", isDirectory: true)
+        let notedDir = vaultDir.appendingPathComponent(".noted", isDirectory: true)
+        try! FileManager.default.createDirectory(at: notedDir, withIntermediateDirectories: true)
+
+        let appSupportDir = tempDir.appendingPathComponent("AppSupport", isDirectory: true)
+        try! FileManager.default.createDirectory(at: appSupportDir, withIntermediateDirectories: true)
+        let globalConfigPath = appSupportDir.appendingPathComponent("settings.yml")
+
+        let vaultYAML = """
+        onBootCommand: opencode
+        fileExtensionFilter: '*.md'
+        templatesDirectory: templates
+        autoSave: true
+        autoPush: false
+        pinnedItems: []
+        """
+        try! vaultYAML.write(to: notedDir.appendingPathComponent("settings.yml"), atomically: true, encoding: .utf8)
+
+        let globalYAML = """
+        githubPAT: ghp_test_token
+        leftSidebarPanes:
+          - files
+          - links
+        rightSidebarPanes:
+          - terminal
+          - tags
+        leftPaneHeights: {}
+        rightPaneHeights: {}
+        collapsedPanes: []
+        fileTreeMode: folder
+        """
+        try! globalYAML.write(to: globalConfigPath, atomically: true, encoding: .utf8)
+
+        let manager = SettingsManager(vaultRoot: vaultDir, globalConfigPath: globalConfigPath.path)
+
+        XCTAssertEqual(manager.leftSidebarPanes, [.files, .links])
+        XCTAssertEqual(manager.rightSidebarPanes, [.terminal, .tags])
+        XCTAssertEqual(manager.leftPaneHeights, [:])
+        XCTAssertEqual(manager.rightPaneHeights, [:])
+        XCTAssertEqual(manager.collapsedPanes, [])
+        XCTAssertEqual(manager.fileTreeMode, .folder)
+        XCTAssertEqual(manager.githubPAT, "ghp_test_token")
     }
 
     func test_vaultSpecificSettings_otherSettingsGoToNotedFolder() {
@@ -525,16 +608,18 @@ final class SettingsManagerTests: XCTestCase {
         manager.autoSave = true
 
         // Verify all these settings are in vault config
-        let notedSettingsFile = vaultDir.appendingPathComponent(".noted/settings.json")
-        let data = try! Data(contentsOf: notedSettingsFile)
-        let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let notedSettingsFile = vaultDir.appendingPathComponent(".noted/settings.yml")
+        let yaml = try! String(contentsOf: notedSettingsFile, encoding: .utf8)
 
-        XCTAssertEqual(json["onBootCommand"] as? String, "npm start")
-        XCTAssertEqual(json["fileExtensionFilter"] as? String, "*.md, *.swift")
-        XCTAssertEqual(json["hiddenFileFolderFilter"] as? String, ".git, .build")
-        XCTAssertEqual(json["templatesDirectory"] as? String, "my-templates")
-        XCTAssertEqual(json["dailyNotesEnabled"] as? Bool, true)
-        XCTAssertEqual(json["autoSave"] as? Bool, true)
+        XCTAssertTrue(yaml.contains("onBootCommand:"))
+        XCTAssertTrue(yaml.contains("npm start"))
+        XCTAssertTrue(yaml.contains("fileExtensionFilter:"))
+        XCTAssertTrue(yaml.contains("*.md, *.swift"))
+        XCTAssertTrue(yaml.contains("hiddenFileFolderFilter:"))
+        XCTAssertTrue(yaml.contains(".git, .build"))
+        XCTAssertTrue(yaml.contains("templatesDirectory: my-templates"))
+        XCTAssertTrue(yaml.contains("dailyNotesEnabled: true"))
+        XCTAssertTrue(yaml.contains("autoSave: true"))
     }
 
     func test_vaultSpecificSettings_withoutVaultRootUsesDefaults() {
@@ -574,5 +659,45 @@ final class SettingsManagerTests: XCTestCase {
         let newManager2 = SettingsManager(vaultRoot: vault2)
         XCTAssertEqual(newManager2.fileExtensionFilter, "*.swift")
         XCTAssertEqual(newManager2.onBootCommand, "vault2-cmd")
+    }
+
+    func test_vaultSpecificSettings_loadsExistingYAMLFile() {
+        let vaultDir = tempDir.appendingPathComponent("VaultYAML", isDirectory: true)
+        let notedDir = vaultDir.appendingPathComponent(".noted", isDirectory: true)
+        try! FileManager.default.createDirectory(at: notedDir, withIntermediateDirectories: true)
+
+        let yaml = """
+        onBootCommand: opencode
+        fileExtensionFilter: '*.md, *.swift'
+        hiddenFileFolderFilter: .git
+        templatesDirectory: templates
+        dailyNotesEnabled: true
+        dailyNotesFolder: daily
+        dailyNotesTemplate: Daily Note.md
+        dailyNotesOpenOnStartup: true
+        autoSave: true
+        autoPush: false
+        leftSidebarPanes:
+          - files
+          - tags
+        rightSidebarPanes:
+          - terminal
+        leftPaneHeights: {}
+        rightPaneHeights: {}
+        collapsedPanes: []
+        fileTreeMode: folder
+        pinnedItems: []
+        """
+        try! yaml.write(to: notedDir.appendingPathComponent("settings.yml"), atomically: true, encoding: .utf8)
+
+        let manager = SettingsManager(vaultRoot: vaultDir)
+
+        XCTAssertEqual(manager.onBootCommand, "opencode")
+        XCTAssertEqual(manager.fileExtensionFilter, "*.md, *.swift")
+        XCTAssertEqual(manager.hiddenFileFolderFilter, ".git")
+        XCTAssertTrue(manager.dailyNotesEnabled)
+        XCTAssertTrue(manager.autoSave)
+        XCTAssertEqual(manager.leftSidebarPanes, [.files, .tags, .links])
+        XCTAssertEqual(manager.rightSidebarPanes, [.terminal])
     }
 }

--- a/marketing-site/docs/index.md
+++ b/marketing-site/docs/index.md
@@ -72,11 +72,11 @@ Customize left and right sidebars with panes:
 Easily publish specific notes to GitHub Gists using your Personal Access Token (PAT).
 
 ### Vault-Specific Settings
-Settings automatically sync with your vault. When you open a vault, Synapse stores its settings in a `.noted` folder at the vault root:
+Settings automatically sync with your vault. When you open a vault, Synapse stores its settings in `.noted/settings.yml` at the vault root:
 - **Portable Settings** — Settings travel with the vault, perfect for syncing via Git or cloud storage
 - **Vault Independence** — Each vault has its own independent settings
 - **Visible & Controllable** — The `.noted` folder appears in your file tree; you control whether to commit it
-- **Privacy Protected** — Your GitHub Personal Access Token stays local and never leaves your machine
+- **Privacy Protected** — Your GitHub Personal Access Token stays local in `~/Library/Application Support/Synapse/settings.yml` and never leaves your machine
 
 ## Settings
 

--- a/project.yml
+++ b/project.yml
@@ -13,6 +13,9 @@ packages:
   Grape:
     url: https://github.com/SwiftGraphs/Grape
     from: 1.1.0
+  Yams:
+    url: https://github.com/jpsim/Yams
+    from: 6.2.1
 
 targets:
   Synapse:
@@ -37,6 +40,7 @@ targets:
     dependencies:
       - package: SwiftTerm
       - package: Grape
+      - package: Yams
     entitlements:
       path: Synapse/Synapse.entitlements
       properties:


### PR DESCRIPTION
Closes #39

## Summary

This PR implements vault-specific settings storage using a ".noted" folder at the vault root.

### Changes

- **SettingsManager.swift**: Added support for two-tier settings system
  - Vault-specific settings stored in ".noted/settings.yml"
  - Sensitive settings (GitHub PAT) remain in Application Support
  - New `init(vaultRoot:)` initializer for vault-specific initialization
  - Automatic creation of .noted folder when vault is opened

- **AppState.swift**: Reload settings when opening a vault
  - Added `reloadSettingsForVault()` method
  - Settings reload automatically when switching between vaults

- **SettingsManagerTests.swift**: Added comprehensive tests
  - Tests for vault-specific settings persistence
  - Tests verifying sensitive settings stay in Application Support
  - Tests for default values when no vault is open
  - Tests for automatic .noted folder creation

### Behavior

1. When a vault is opened: Settings are read from `.noted/settings.yml`
2. When no vault is open: Default values are used
3. GitHub PAT stays in `~/Library/Application Support/Synapse/settings.yml`
4. `.noted` folder is visible in the file tree (no special hiding)
5. No automatic migration from existing settings

### Testing

All 652 tests pass, including 6 new tests specifically for this feature.
